### PR TITLE
Fix to allow mark up in CSV table again

### DIFF
--- a/src/main/resources/hudson/plugins/plot/PlotReport/index.jelly
+++ b/src/main/resources/hudson/plugins/plot/PlotReport/index.jelly
@@ -24,7 +24,7 @@
                 <th> ${col} </th>
               </j:if>
               <j:if test="${loopStat3.index>0}">
-                <td> ${col} </td>
+                <td> <j:out value="${col}"/> </td>
               </j:if>
             </j:forEach>
             </tr>


### PR DESCRIPTION
Markup in the CSV table was being displayed as plain text after the addition of <?jelly escape-by-default='true'?> for XSS prevention.  This fix allows markup in the table again.

<!-- Link to Jira ticket, https://issues.jenkins-ci.org
     good to have, but optional
 -->
Jira: [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX)

<!-- Comment:
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * JIRA issues for minor improvements are not mandatory.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
 * Issue ID should be included in PR name (e.g. "[JENKINS-XXXXX] Add feature X.Y.Z".
-->

### What has been done
1.
2.

<!-- optional. Should be removed if not applicable -->
### Screenshots

Before | After
:-: | :-:
| |

### How to test
1.
2.

### Checklist

- [ ] Git commits follow [best practices](https://chris.beams.io/posts/git-commit/) <!-- mandatory -->
- [ ] Build passes in Jenkins <!-- mandatory -->
- [ ] Appropriate tests or explanation to why this change has no tests <!-- mandatory -->
- [ ] JIRA issue is well described (problem explanation, steps to reproduce, screenshots) <!-- optional -->
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

